### PR TITLE
Filter patterns with empty title

### DIFF
--- a/src/main/scala/codacy/pmd/DocGenerator.scala
+++ b/src/main/scala/codacy/pmd/DocGenerator.scala
@@ -167,7 +167,7 @@ object DocGenerator {
     (for {
       rule <- xml \\ "rule"
       name = rule \@ "name"
-      message = rule \@ "message"
+      message = rule \@ "message" if message.nonEmpty
     } yield {
       val (parameterDescriptions, parameterSpecifications) = parseParameters(rule).to[Set].unzip
       val rulesetNameClean = rulesetName.stripSuffix(".xml")


### PR DESCRIPTION
- Problem with deprecated rules that refer to other
example: https://github.com/pmd/pmd/blob/master/pmd-java/src/main/resources/rulesets/java/design.xml#L13

- Another option would be to follow the "ref", which must be done with caution to avoid loops for instance

Internal track system issue: FT-2814