### PR TITLE
fix: Don't analyse any file when empty list of files

### DIFF
--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/patterns.xml
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="ruleset\.xml|sample\.java" />
+    </module>
+</module>

--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/results.xml
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/results.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<checkstyle version="4.3"></checkstyle>

--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/src/ruleset.xml
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/src/ruleset.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>Test Rule</description>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable" />
+</ruleset>

--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.java
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.java
@@ -1,0 +1,8 @@
+public class Foo {
+    public void sample() {
+        int i = 5;
+        int foo = 5;
+        System.out.println(foo);
+    }
+}
+

--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.jsm
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.jsm
@@ -1,0 +1,7 @@
+const name = 'Josh Perez';
+const element = <h1>Hello, {name}</h1>;
+
+ReactDOM.render(
+    element,
+    document.getElementById('root')
+);

--- a/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.vue
+++ b/src/main/resources/docs/multiple-tests/empty-filtered-list/src/sample.vue
@@ -1,0 +1,10 @@
+<template>
+  <h1>Sample</h1>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style>
+</style>

--- a/src/main/scala/com/codacy/pmd/PMD.scala
+++ b/src/main/scala/com/codacy/pmd/PMD.scala
@@ -40,7 +40,10 @@ object PMD extends Tool {
           .filter(filename => !Languages.invalidExtensions.exists(filename.endsWith))
           .mkString(",")
     }
-    pmdConfig.setInputPaths(filesStr)
+
+    if (filesStr.nonEmpty) {
+      pmdConfig.setInputPaths(filesStr)
+    }
 
     configuration match {
       case Some(config) =>


### PR DESCRIPTION
When list of files to analyse was empty, PMD was trying to analyse file with empty name